### PR TITLE
Add contact form

### DIFF
--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -10,7 +10,8 @@ main:
     weight: 20    
   - identifier: contact
     name: Submit request
-    url: "mailto:hola@juanddddiego.com"
+    params:
+      contact-form-id: Me766E
     weight: 30
   - identifier: bookings
     name: Book a meeting

--- a/config/_default/menus.es.yaml
+++ b/config/_default/menus.es.yaml
@@ -10,7 +10,8 @@ main:
     weight: 20
   - identifier: contact
     name: Envíame tu propuesta
-    url: "mailto:hola@juanddddiego.com"
+    params:
+      contact-form-id: dWk8Yq
     weight: 30
   - identifier: bookings
     name: Haz una reserva

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -23,7 +23,5 @@ cover:
 socialIcons:
   - name: "spotify"
     url: "https://open.spotify.com/playlist/3WrrhhFvoOLKok67IesmZG"
-  - name: "email"
-    url: "mailto:hola@juanddddiego.com"
   - name: "cv"
     url: "https://credits.muso.ai/profile/5543b45b-aaec-425e-aa7b-51cd5717c751"

--- a/config/production/params.yaml
+++ b/config/production/params.yaml
@@ -25,7 +25,5 @@ cover:
 socialIcons:
   - name: "spotify"
     url: "https://open.spotify.com/playlist/3WrrhhFvoOLKok67IesmZG"
-  - name: "email"
-    url: "mailto:hola@juanddddiego.com"
   - name: "cv"
     url: "https://credits.muso.ai/profile/5543b45b-aaec-425e-aa7b-51cd5717c751"

--- a/layouts/partials/contact-form.html
+++ b/layouts/partials/contact-form.html
@@ -1,0 +1,1 @@
+<script async src="https://tally.so/widgets/embed.js"></script>

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -8,4 +8,6 @@
         crossorigin="anonymous"
         referrerpolicy="no-referrer"
 />
+{{- partial "counter-dev.html" . -}}
+{{- partial "contact-form.html" . -}}
 {{- /* Head custom content area end */ -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -145,7 +145,7 @@
                 {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
                 {{- $is_contact := eq .Identifier "contact" }}
                 {{- $tally_id := index .Params "contact-form-id" }}
-                <li{{ if $is_contact }} data-tally-open="{{ $tally_id }}" data-tally-emoji-text="👋" data-tally-emoji-animation="wave" data-tally-auto-close="0"{{ end }}>
+                <li{{ if $is_contact }} data-tally-open="{{ $tally_id }}" data-tally-emoji-text="🤙" data-tally-emoji-animation="wave" data-tally-auto-close="0" onclick="document.getElementById('ham-menu-toggle').checked = false;"{{ end }}>
                     <a href="{{ if $is_contact }}#{{ else }}{{ .URL | absLangURL }}{{ end }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
                     {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
                         <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -145,7 +145,7 @@
                 {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
                 {{- $is_contact := eq .Identifier "contact" }}
                 {{- $tally_id := index .Params "contact-form-id" }}
-                <li{{ if $is_contact }} data-tally-open="{{ $tally_id }}" data-tally-emoji-text="🤙" data-tally-emoji-animation="wave" data-tally-auto-close="0" onclick="document.getElementById('ham-menu-toggle').checked = false;"{{ end }}>
+                <li{{ if $is_contact }} data-tally-open="{{ $tally_id }}" data-tally-emoji-text="🤙" data-tally-emoji-animation="wave" data-tally-auto-close="4000" onclick="document.getElementById('ham-menu-toggle').checked = false;"{{ end }}>
                     <a href="{{ if $is_contact }}#{{ else }}{{ .URL | absLangURL }}{{ end }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
                     {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
                         <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -143,8 +143,10 @@
                 {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }}
                 {{- $page_url:= $currentPage.Permalink | absLangURL }}
                 {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
-                <li>
-                    <a href="{{ .URL | absLangURL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
+                {{- $is_contact := eq .Identifier "contact" }}
+                {{- $tally_id := index .Params "contact-form-id" }}
+                <li{{ if $is_contact }} data-tally-open="{{ $tally_id }}" data-tally-emoji-text="👋" data-tally-emoji-animation="wave" data-tally-auto-close="0"{{ end }}>
+                    <a href="{{ if $is_contact }}#{{ else }}{{ .URL | absLangURL }}{{ end }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
                     {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
                         <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>
                             {{- .Pre }}


### PR DESCRIPTION
Tally will provide a contact form, so I can remove the contact mail from the webpage code.
Tally form is embedded as a popup in the right bottom corner of my site.
It's responsive, so in smaller viewport dimensions it appears in the center.
Tally form is loaded when clicking on the "contact me" li element inside the header navigation bar.
Navigation bar is closed just when clicking on that particular li element.